### PR TITLE
Add interactive book list component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import BookList from '../components/BookList'
+
 export default function HomePage() {
   return (
     <main className="container mx-auto px-4 py-8">
@@ -59,6 +61,11 @@ export default function HomePage() {
             Framework setup complete! Ready for feature development.
           </p>
         </div>
+
+        <section className="mt-12">
+          <h2 className="mb-4 text-2xl font-semibold text-gray-900">Your TBR List</h2>
+          <BookList />
+        </section>
       </div>
     </main>
   )

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import type { Book } from '../types'
+
+export default function BookList() {
+  const [books, setBooks] = useState<Book[]>([])
+  const [title, setTitle] = useState('')
+  const [author, setAuthor] = useState('')
+
+  const canAdd = title.trim() !== '' && author.trim() !== ''
+
+  const addBook = () => {
+    if (!canAdd) return
+
+    const newBook: Book = {
+      id: Date.now().toString(),
+      title: title.trim(),
+      author: author.trim(),
+      dateAdded: new Date(),
+      status: 'to-read',
+    }
+
+    setBooks((prev) => [...prev, newBook])
+    setTitle('')
+    setAuthor('')
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-col gap-2 md:flex-row">
+        <div>
+          <label htmlFor="title" className="sr-only">
+            Title
+          </label>
+          <input
+            id="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Title"
+            className="w-full rounded border p-2"
+          />
+        </div>
+        <div>
+          <label htmlFor="author" className="sr-only">
+            Author
+          </label>
+          <input
+            id="author"
+            value={author}
+            onChange={(e) => setAuthor(e.target.value)}
+            placeholder="Author"
+            className="w-full rounded border p-2"
+          />
+        </div>
+        <button
+          onClick={addBook}
+          disabled={!canAdd}
+          className="rounded bg-primary-600 px-4 py-2 font-semibold text-white transition-colors duration-200 disabled:cursor-not-allowed disabled:bg-gray-300 hover:bg-primary-700"
+        >
+          Add Book
+        </button>
+      </div>
+      <ul className="list-disc pl-5">
+        {books.map((book) => (
+          <li key={book.id} className="mb-1">
+            {book.title} by {book.author}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/__tests__/BookList.test.tsx
+++ b/src/components/__tests__/BookList.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import BookList from '../BookList'
+
+describe('BookList', () => {
+  it('allows users to add books to the list', async () => {
+    const user = userEvent.setup()
+    render(<BookList />)
+
+    const titleInput = screen.getByLabelText(/title/i)
+    const authorInput = screen.getByLabelText(/author/i)
+    const addButton = screen.getByRole('button', { name: /add book/i })
+
+    await user.type(titleInput, 'The Hobbit')
+    await user.type(authorInput, 'J.R.R. Tolkien')
+    await user.click(addButton)
+
+    expect(screen.getByText(/the hobbit/i)).toBeInTheDocument()
+    expect(titleInput).toHaveValue('')
+    expect(authorInput).toHaveValue('')
+  })
+
+  it('disables the add button when inputs are empty', async () => {
+    const user = userEvent.setup()
+    render(<BookList />)
+
+    const titleInput = screen.getByLabelText(/title/i)
+    const authorInput = screen.getByLabelText(/author/i)
+    const addButton = screen.getByRole('button', { name: /add book/i })
+
+    expect(addButton).toBeDisabled()
+    await user.type(titleInput, 'Some Book')
+    expect(addButton).toBeDisabled()
+    await user.type(authorInput, 'Some Author')
+    expect(addButton).toBeEnabled()
+  })
+})


### PR DESCRIPTION
## Summary
- add client-side BookList component for tracking books locally
- integrate BookList into home page with new "Your TBR List" section
- cover BookList with tests for adding books and button state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a56f424b28832998f1557d5943b5eb